### PR TITLE
Milano: add contats to event page, update organizers in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @kristoff-it
 
 # Zig Day Organizers
-/content/europe/milano/ @inge4pres
+/content/europe/milano/ @inge4pres @tpreviero @omissis @ludovicobesana
 /content/usa/portland/ @andrewrk @MasonRemaley
 /content/canada/vancouver/ @mattnite
 /content/usa/san-francisco/ @AdjectiveAllison

--- a/content/europe/milano/index.smd
+++ b/content/europe/milano/index.smd
@@ -60,3 +60,13 @@ Join the community in our channels to meet other ziglers in the Bel Paese:
 * Telegram channel [Zig Italia](https://t.me/ziglang_it)
 * [Zig User Group Italia](https://www.meetup.com/it-IT/italia-zig-user-group) on `meetup.com`
 
+### Contacts
+
+People making Zig Day Milano possible (in alphabetical order):
+
+* [Claudio Beatrice](https://github.com/omissis)
+* [Francesco Gualazzi](https://github.com/inge4pres)
+* [Ludovico Besana](https://github.com/ludovicobesana)
+* [Tommaso Previero](https://github.com/tpreviero)
+
+


### PR DESCRIPTION
Zig Day Milano event planning and setup are a shared effort.
Include the relevant people in:

- CODEOWNERS: add Milano organizers
- Milano content: include a section with references to GitHub handle of organizers